### PR TITLE
Fix issue with url parser

### DIFF
--- a/system/pip.php
+++ b/system/pip.php
@@ -10,12 +10,12 @@ function pip()
     $url = '';
 	
 	// Get request url and script url
-	$request_url = (isset($_SERVER['REQUEST_URI'])) ? $_SERVER['REQUEST_URI'] : '';
+	$request_url = (isset($_SERVER['REQUEST_URI'])) ? parse_url(strtolower($_SERVER['REQUEST_URI'])) : '';
 	$script_url  = (isset($_SERVER['PHP_SELF'])) ? $_SERVER['PHP_SELF'] : '';
-    	
+
 	// Get our url path and trim the / of the left and the right
-	if($request_url != $script_url) $url = trim(preg_replace('/'. str_replace('/', '\/', str_replace('index.php', '', $script_url)) .'/', '', $request_url, 1), '/');
-    
+	if($request_url != $script_url) $url = trim(preg_replace('/'. str_replace('/', '\/', strtolower(str_replace('index.php', '', $script_url))) .'/', '', $request_url['path'], 1), '/');
+
 	// Split the url into segments
 	$segments = explode('/', $url);
 	
@@ -38,7 +38,7 @@ function pip()
         require_once(APP_DIR . 'controllers/' . $controller . '.php');
         $action = 'index';
     }
-	
+
 	// Create object and call method
 	$obj = new $controller;
     die(call_user_func_array(array($obj, $action), array_slice($segments, 2)));


### PR DESCRIPTION
Parser made url case sensitive, now case no longer matters. www.HELLO.com == www.hello.com

You can also pass in query strings: ?id=2&something=3

Url parser did not effectively remove these before, causing 404 errors.